### PR TITLE
Añadir votación de esculturas y actualizar servicios

### DIFF
--- a/BackEnd-solucion/APIController/Controllers/EsculturasController.cs
+++ b/BackEnd-solucion/APIController/Controllers/EsculturasController.cs
@@ -109,7 +109,7 @@ namespace APIBienal.Controllers
          return Ok(esculturaUpdate);
     }
 
-    [HttpPatch("{id}")]
+        [HttpPatch("{id}")]
         public async Task<IActionResult> ActualizarPropiedadEscultura(int id, [FromForm] EsculturaPatch request)
         {
             Esculturas? esculturaUpdate = await this.esculturaService.UpdatePatchAsync(id, request);
@@ -119,6 +119,18 @@ namespace APIBienal.Controllers
             }
             return Ok(esculturaUpdate);
         }
+        //Voto de Escultura
+        [HttpPatch("{id}/Votar")]
+        public async Task<IActionResult> Votacion(int id, [FromForm] EsculturaVoto request)
+        {
+            Esculturas? esculturaUpdate = await this.esculturaService.VoteEscultura(id, request);
+            if (esculturaUpdate == null)
+            {
+                return NotFound("Ocurrio un error al votar la escultura. Intentelo nuevamente. Verifique si existe la escultura");
+            }
+            return Ok(esculturaUpdate);
+        }
+
 
         //implementar patch con imagen para escultura
 

--- a/BackEnd-solucion/APIController/Program.cs
+++ b/BackEnd-solucion/APIController/Program.cs
@@ -16,7 +16,7 @@ var connectionString = builder.Configuration.GetConnectionString("Connection");
 builder.Services.AddDbContext<BienalDbContext>(options => options.UseSqlServer(connectionString,
      b => b.MigrationsAssembly("APIController")));
 
-builder.Services.AddScoped<IAzureStorageService, AzureBlobStorageService>();
+builder.Services.AddScoped<IAzureStorageService, AzureBlobStorageService>();            
 
 builder.Services.AddScoped<ICRUDEsculturaService, EsculturasServices>();
 builder.Services.AddScoped<ICRUDServiceEvent, EventosServices>();

--- a/BackEnd-solucion/BienalModel/Esculturas.cs
+++ b/BackEnd-solucion/BienalModel/Esculturas.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Entidades
@@ -27,6 +28,12 @@ namespace Entidades
         public DateOnly FechaCreacion { get; set; } = DateOnly.FromDateTime(DateTime.Now);
 
         public string? Tematica { get; set; }
+
+        public int CantVotaciones { get; set; }
+        [JsonIgnore]
+        public int Votos { get; set; }
+        //atributo cal ulado Votos/CantVotaciones
+        public double PromedioVotos { get; set; }
    
     }
 }

--- a/BackEnd-solucion/Requests/EsculturaRequest.cs
+++ b/BackEnd-solucion/Requests/EsculturaRequest.cs
@@ -33,4 +33,9 @@ namespace Requests
         public DateOnly? FechaCreacion { get; set; }
         public string? Tematica { get; set; }
     }
+
+    public class EsculturaVoto
+    {
+        public int Voto { get; set; }
+    }
 }

--- a/BackEnd-solucion/Servicios/EsculturaServices.cs
+++ b/BackEnd-solucion/Servicios/EsculturaServices.cs
@@ -133,6 +133,24 @@ namespace Servicios
             return esculturaToUpdate;
         }
 
+        public async Task<Esculturas> VoteEscultura(int id, EsculturaVoto request)
+            {
+                var escultura = await this._context.Esculturas.FindAsync(id);
+                
+                if (escultura == null)
+                {
+                    throw new Exception("Escultura no encontrada");
+                }
+
+                escultura.Votos += request.Voto;
+                escultura.CantVotaciones++;
+                escultura.PromedioVotos = escultura.Votos / escultura.CantVotaciones;
+
+                this._context.Update(escultura);
+                await this._context.SaveChangesAsync();
+                return escultura;
+        }
+
         public async Task<Esculturas>? UpdatePatchAsync(int id, EsculturaPatch request)
         {
             var esculturaToUpdate = await this._context.Esculturas.FindAsync(id);
@@ -206,6 +224,7 @@ namespace Servicios
         Task<Esculturas>? GetByAsync(int id); 
         Task<Esculturas>? UpdatePutEsculturaAsync(int id, EsculturaPostPut request);
         Task<Esculturas>? UpdatePatchAsync(int id, EsculturaPatch request);
+        Task<Esculturas> VoteEscultura(int id, EsculturaVoto request);
         Task<bool> DeleteAsync(int id);
         
     } 


### PR DESCRIPTION
Se ha añadido un nuevo método `Votacion` en el controlador `EsculturasController` para permitir la votación de esculturas usando el verbo HTTP `PATCH` y la ruta `"{id}/Votar"`.

Se ha agregado la clase `EsculturaVoto` en `EsculturaRequest.cs` para manejar las votaciones.

En `Esculturas.cs`, se han añadido las propiedades `CantVotaciones`, `Votos` y `PromedioVotos` para gestionar y calcular el promedio de votos de una escultura. La propiedad `Votos` está marcada con el atributo `[JsonIgnore]` para evitar su serialización.

Se ha implementado el método `VoteEscultura` en `EsculturaServices.cs` que actualiza los votos de una escultura, incrementa el contador de votaciones y recalcula el promedio de votos.

Se ha actualizado la interfaz de servicios `ICRUDEsculturaService` para incluir la definición del método `VoteEscultura`.

Se ha añadido la directiva `using System.Text.Json.Serialization;` en `Esculturas.cs` para manejar la serialización JSON.

Se ha realizado una pequeña corrección de formato en `Program.cs` sin cambios funcionales.