### PR TITLE
Actualiza configuración de Swagger a versión 1.1

### DIFF
--- a/BackEnd-solucion/APIController/Program.cs
+++ b/BackEnd-solucion/APIController/Program.cs
@@ -8,6 +8,7 @@ using Servicios;
 using Entidades;
 using Requests;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -53,7 +54,11 @@ builder.Services.AddControllers();
 
 // Configuración de Swagger/OpenAPI
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bienal API", Version = "V1.1" });
+});
 
 builder.Services.AddCors();
 
@@ -63,7 +68,10 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(c =>
+    {
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Bienal API V1.1");
+    });
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
Se ha añadido la importación de `Microsoft.OpenApi.Models` en el archivo `Program.cs` para permitir una configuración más detallada de Swagger.

Se ha modificado la configuración de Swagger/OpenAPI para incluir una descripción del documento Swagger con el título "Bienal API" y la versión "V1.1".

Se ha actualizado la configuración de la interfaz de usuario de Swagger para que apunte al nuevo endpoint `/swagger/v1/swagger.json` con el título "Bienal API V1.1".